### PR TITLE
Too much text in the story details overflows the box and shows up on the

### DIFF
--- a/public/stylesheets/new.css
+++ b/public/stylesheets/new.css
@@ -2386,7 +2386,8 @@ img.drop-arrow {
 }
 
 .item-description-text .text-wrapper {
-  width: 80%;
+  width: 100%;
+  overflow-x: scroll;
 }
 
 .item-estimate select {


### PR DESCRIPTION
background.